### PR TITLE
Update config layout and dropdowns

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -16,7 +16,8 @@ function ensureConfigSheet() {
   let sheet = ss.getSheetByName('999-config');
   if (!sheet) {
     sheet = ss.insertSheet('999-config');
-    sheet.getRange(1, 1, 1, 3).setValues([['Key', 'Value', 'Description']]);
+    sheet.getRange(1, 1, 1, 2).setValues([['Description', 'Value']]);
+    sheet.hideColumns(3); // store keys internally
   }
   return sheet;
 }
@@ -26,7 +27,7 @@ function readConfig(key) {
   if (!sheet) return '';
   const data = sheet.getDataRange().getValues();
   for (let i = 1; i < data.length; i++) {
-    if (data[i][0] === key) return data[i][1];
+    if (data[i][2] === key) return data[i][1];
   }
   return '';
 }
@@ -35,12 +36,12 @@ function writeConfig(key, value) {
   const sheet = ensureConfigSheet();
   const data = sheet.getDataRange().getValues();
   for (let i = 1; i < data.length; i++) {
-    if (data[i][0] === key) {
+    if (data[i][2] === key) {
       sheet.getRange(i + 1, 2).setValue(value);
       return;
     }
   }
-  sheet.appendRow([key, value]);
+  sheet.appendRow(['', value, key]);
 }
 
 function getColumnConfig(propName) {
@@ -293,25 +294,26 @@ function setupColumnsForThisSheet() {
 
   // Clear existing config and write headers
   sheet.clear();
-  sheet.getRange(1, 1, 1, 3)
-       .setValues([['Key', 'Value', 'Description']]);
+  sheet.getRange(1, 1, 1, 2)
+       .setValues([['Description', 'Value']]);
 
   const rows = [
-    ['SHEET_NAME',                '', 'Write the name of sheet you want to run the script'],
-    ['COMPANY_COL_LETTER',        '', 'Column letter for Company name'],
-    ['WEBSITE_COL_LETTER',        '', 'Column letter for Website URL'],
-    ['CUSTOM_INDUSTRY_COL_LETTER','', 'Column letter for Industry'],
-    ['OWNER_COL_LETTER',          '', 'Column letter for Owner/Founder name'],
-    ['OWNER_EMAIL_COL_LETTER',    '', 'Column letter for Owner email address'],
-    ['OWNER_LINKEDIN_COL_LETTER', '', 'Column letter for Owner LinkedIn URL'],
-    ['OUTPUT_COL_LETTER',         '', 'Column letter for output customization'],
-    ['FIND_OWNER_INFO_COL_LETTER','', 'Column letter to flag which rows to process'],
-    ['SEQUENCE_ID_COL_LETTER',    '', 'Column letter for Sequence ID'],
-    ['SENDER_ID_COL_LETTER',      '', 'Column letter for Sender ID']
+    ['Sheet name (e.g., Sheet 1)', '', 'SHEET_NAME'],
+    ['Column letter for Company name', '', 'COMPANY_COL_LETTER'],
+    ['Column letter for Website URL', '', 'WEBSITE_COL_LETTER'],
+    ['Column letter for Industry', '', 'CUSTOM_INDUSTRY_COL_LETTER'],
+    ['Column letter for Owner/Founder name', '', 'OWNER_COL_LETTER'],
+    ['Column letter for Owner email address', '', 'OWNER_EMAIL_COL_LETTER'],
+    ['Column letter for Owner LinkedIn URL', '', 'OWNER_LINKEDIN_COL_LETTER'],
+    ['Column letter for output customization', '', 'OUTPUT_COL_LETTER'],
+    ['Column letter to flag which rows to process', '', 'FIND_OWNER_INFO_COL_LETTER'],
+    ['Column letter for Sequence ID', '', 'SEQUENCE_ID_COL_LETTER'],
+    ['Column letter for Sender ID', '', 'SENDER_ID_COL_LETTER']
   ];
 
   sheet.getRange(2, 1, rows.length, 3).setValues(rows);
-  sheet.getRange(2, 3, rows.length, 1).setFontStyle('italic');
+  sheet.getRange(2, 1, rows.length, 1).setFontStyle('italic');
+  sheet.hideColumns(3);
 
   ui.alert('✔ 999-config sheet initialized. Please fill in the values and rerun the setup when done.');
 }
@@ -1301,6 +1303,7 @@ function getMXDomain(email) {
 function refreshLookups() {
    refreshSenders();
    refreshSequences();
+   applyLookupDropdowns();
 }
 
 function getApiKey(keyName) {


### PR DESCRIPTION
## Summary
- simplify `999-config` sheet with only Description and Value columns
- hide internal key column and adjust config helpers
- update column setup text and refresh dropdowns after lookup updates

## Testing
- `node -c Code.js`

------
https://chatgpt.com/codex/tasks/task_e_687abbdf07388322be4887718f7a9aa3