### PR TITLE
Implement MySQL activity logging

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -8,7 +8,8 @@
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/script.scriptapp",
     "https://www.googleapis.com/auth/script.container.ui",
-    "https://www.googleapis.com/auth/userinfo.email"
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/sqlservice"
   ],
   "urlFetchWhitelist": [
     "https://api.anthropic.com/",


### PR DESCRIPTION
## Summary
- extend API setup to store MySQL connection parameters
- add helper functions for MySQL and logging user activity
- log enrichment and customization counts per user
- allow admins to sync credits from the MySQL table
- expose new menu item
- add SQL service scope

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687abefe02948322b6924d6719eeba02