### PR TITLE
Fix missing catch for outer try in enrichData

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1787,7 +1787,11 @@ function enrichData() {
       SpreadsheetApp.getUi().alert('An unexpected error occurred. Please check the logs for details.');
       endLog(__log, 'ERROR: ' + e.message, {rows: rowsInfo});
     }
+  } catch (err) {
+    endLog(__log, 'ERROR: ' + err.message, {rows: rowsInfo});
+    throw err;
   }
+}
 
 /**
  * Fetch from Anthropic with a 30‑calls/minute shared rate limit.


### PR DESCRIPTION
## Summary
- close the outer `try` block in `enrichData`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ba8b358b4832288a36cfd0f878e2e