### PR TITLE
Add duration and row count logging

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -66,24 +66,28 @@ function ensureLogsSheet() {
   let sheet = ss.getSheetByName('logs');
   if (!sheet) {
     sheet = ss.insertSheet('logs');
-    sheet.getRange(1, 1, 1, 4)
+    sheet.getRange(1, 1, 1, 6)
          .setValues([[
            'Timestamp',
            'User Email',
            'Function',
-           'Status'
+           'Status',
+           'Duration (sec)',
+           'Rows'
          ]]);
   }
   return sheet;
 }
 
-function logAction(funcName, status) {
+function logAction(funcName, status, duration, rows) {
   const sheet = ensureLogsSheet();
   sheet.appendRow([
     new Date(),
     Session.getActiveUser().getEmail(),
     funcName,
-    status
+    status,
+    duration || '',
+    rows === undefined ? '' : rows
   ]);
 }
 
@@ -341,6 +345,7 @@ function onOpen(e) {
  */
 function setupColumnsForThisSheet() {
   const fn = 'setupColumnsForThisSheet';
+  const start = Date.now();
   try {
     requireAdmin();
 
@@ -390,9 +395,9 @@ function setupColumnsForThisSheet() {
 
     ensureLogsSheet();
     ui.alert('✔ // Config sheet created. Please fill in the values before running any function.');
-    logAction(fn, 'Completed');
+    logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
   } catch (e) {
-    logAction(fn, 'Failed: ' + e.message);
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
     throw e;
   }
 }
@@ -401,8 +406,11 @@ function setupColumnsForThisSheet() {
  * Prompt for API keys (Anthropic, Apollo, OpenAI and BrightData).
  */
 function setupApiKey() {
-  requireAdmin();
-  const ui = SpreadsheetApp.getUi();
+  const fn = 'setupApiKey';
+  const start = Date.now();
+  try {
+    requireAdmin();
+    const ui = SpreadsheetApp.getUi();
   const scriptProps = PropertiesService.getScriptProperties();
   const apiKeys = [
     'ANTHROPIC_API_KEY',
@@ -426,6 +434,11 @@ function setupApiKey() {
   });
 
   ui.alert('API keys saved to Script Properties');
+  logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
+  } catch (e) {
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
+    throw e;
+  }
 }
 
 /**
@@ -1034,6 +1047,9 @@ function refreshSequences() {
  *   ⑤ Enrol the contact in the chosen sequence
  */
 function uploadContacts() {
+  const fn = 'uploadContacts';
+  const start = Date.now();
+  try {
   // --- As configurações globais e da planilha continuam iguais ---
   const activeSS = SpreadsheetApp.getActiveSpreadsheet();
   const sheet    = activeSS.getSheetByName(getConfig('SHEET_NAME'));
@@ -1151,6 +1167,11 @@ const senderMap = buildLookupMap(activeSS, 'Senders_Lookup');
   });
 
   SpreadsheetApp.getUi().alert(`Uploaded ${processed} contacts to Apollo.`);
+  logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
+  } catch (e) {
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
+    throw e;
+  }
 }
 
 /**
@@ -1380,9 +1401,17 @@ function getMXDomain(email) {
 }
 
 function refreshLookups() {
+  const fn = 'refreshLookups';
+  const start = Date.now();
+  try {
    refreshSenders();
    refreshSequences();
    applyLookupDropdowns();
+   logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
+  } catch (e) {
+   logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
+   throw e;
+  }
 }
 
 function getApiKey(keyName) {
@@ -1515,6 +1544,8 @@ function findFirstLinkedInResult(ownerName, companyName) {
  */
 function enrichData() {
   const fn = 'enrichData';
+  const start = Date.now();
+  let rowCount = 0;
   try {
     console.log('🚀 Starting the main enrichment process (Optimized)...');
     const startTime = new Date();
@@ -1524,7 +1555,7 @@ function enrichData() {
     if (!sheet) {
       console.error(`Sheet with name "${getConfig('SHEET_NAME')}" not found.`);
       SpreadsheetApp.getUi().alert(`Error: Sheet "${getConfig('SHEET_NAME')}" not found.`);
-      logAction(fn, 'Failed: sheet not found');
+      logAction(fn, 'Failed: sheet not found', Math.round((Date.now()-start)/1000));
       return;
     }
   const allData = sheet.getDataRange().getValues();
@@ -1554,8 +1585,10 @@ function enrichData() {
 
   if (flaggedRows.length === 0) {
     SpreadsheetApp.getUi().alert('No rows were flagged with "1" to process.');
+    logAction(fn, 'Failed: no rows flagged', Math.round((Date.now()-start)/1000), 0);
     return;
   }
+  rowCount = flaggedRows.length;
   console.log(`Found ${flaggedRows.length} rows to process.`);
   let allSheetUpdates = [];
 
@@ -1733,16 +1766,19 @@ function enrichData() {
     const duration = Math.round((new Date() - startTime) / 1000);
     console.log(`✅🎉 Enrichment process completed successfully in ${duration} seconds!`);
     SpreadsheetApp.getUi().alert(`Success!`, `Enriched ${flaggedRows.length} rows.`, SpreadsheetApp.getUi().ButtonSet.OK);
+    logAction(fn, 'Completed', Math.round((Date.now()-start)/1000), rowCount);
 
   } catch (e) {
     console.error(`A critical error occurred during the enrichment process: ${e.toString()}`, e.stack);
     SpreadsheetApp.getUi().alert('An unexpected error occurred. Please check the logs for details.');
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000), rowCount);
   }
-  
+
   // Catch any unexpected errors from the outer try block
 } catch (e) {
   console.error('Unexpected failure in enrichData:', e);
   SpreadsheetApp.getUi().alert('An unexpected error occurred. Please check the logs for details.');
+  logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000), rowCount);
 }
 
 }
@@ -1803,11 +1839,16 @@ function rateLimitedAnthropicFetch(url, options) {
  * NEW - Orchestrates a bulk, in-memory scrape and generates a full email for each flagged row.
  */
 function createFullEmail() {
+  const fn = 'createFullEmail';
+  const start = Date.now();
+  let rowCount = 0;
+  try {
   const ui = SpreadsheetApp.getUi();
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(getConfig('SHEET_NAME'));
   if (!sheet) {
     console.error(`Sheet with name "${getConfig('SHEET_NAME')}" not found.`);
     ui.alert(`Error: Sheet "${getConfig('SHEET_NAME')}" not found.`);
+    logAction(fn, 'Failed: sheet not found', Math.round((Date.now()-start)/1000));
     return;
   }
   const flagCol = letterToColumn(getColumnConfig('FIND_OWNER_INFO_COL_LETTER'));
@@ -1821,8 +1862,10 @@ function createFullEmail() {
 
   if (flaggedRows.length === 0) {
     ui.alert('🛑 No rows flagged with "1" to process.');
+    logAction(fn, 'Failed: no rows flagged', Math.round((Date.now()-start)/1000), 0);
     return;
   }
+  rowCount = flaggedRows.length;
 
   // Prompt user before starting, similar to custom info customization
   const n = flaggedRows.length;
@@ -1949,7 +1992,11 @@ function createFullEmail() {
     `• Emails created: ${emailsCreated}`,
     ui.ButtonSet.OK
   );
-  logAction(fn, 'Completed');
+  logAction(fn, 'Completed', Math.round((Date.now()-start)/1000), rowCount);
+  } catch (e) {
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000), rowCount);
+    throw e;
+  }
 }
 
 /**
@@ -1957,6 +2004,9 @@ function createFullEmail() {
  * Saves Claude's suggested prompt to row EMAIL_PROMPT_ROW of // Config.
  */
 function changeEmailOptimizationStyle() {
+  const fn = 'changeEmailOptimizationStyle';
+  const start = Date.now();
+  try {
   requireAdmin();
   const ui = SpreadsheetApp.getUi();
   const cfg = ensureConfigSheet();
@@ -2029,9 +2079,17 @@ function changeEmailOptimizationStyle() {
   }
   writeConfig('EMAIL_GUIDELINES', newPrompt);
   ui.alert('Email optimization prompt updated.');
+  logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
+  } catch (e) {
+  logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
+  throw e;
+  }
 }
 
 function revertToPreviousCustomization() {
+  const fn = 'revertToPreviousCustomization';
+  const start = Date.now();
+  try {
   const ui = SpreadsheetApp.getUi();
   const cfg = ensureConfigSheet();
   const prev = cfg.getRange(PREVIOUS_PROMPT_ROW, 2).getValue();
@@ -2043,18 +2101,32 @@ function revertToPreviousCustomization() {
   cfg.getRange(PREVIOUS_PROMPT_ROW, 2).setValue(current);
   cfg.getRange(EMAIL_PROMPT_ROW, 2).setValue(prev);
   ui.alert('Reverted to previous customization style.');
+  logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
+  } catch (e) {
+  logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
+  throw e;
+  }
 }
 
 function revertToDefaultCustomization() {
+  const fn = 'revertToDefaultCustomization';
+  const start = Date.now();
+  try {
   const cfg = ensureConfigSheet();
   const current = cfg.getRange(EMAIL_PROMPT_ROW, 2).getValue();
   cfg.getRange(PREVIOUS_PROMPT_ROW, 2).setValue(current);
   cfg.getRange(EMAIL_PROMPT_ROW, 2).setValue(DEFAULT_EMAIL_GUIDELINES);
   SpreadsheetApp.getUi().alert('Reverted to default email customization.');
+  logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
+  } catch (e) {
+  logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
+  throw e;
+  }
 }
 
 function changeCustomInfoStyle() {
   const fn = 'changeCustomInfoStyle';
+  const start = Date.now();
   try {
     requireAdmin();
     const ui = SpreadsheetApp.getUi();
@@ -2130,15 +2202,16 @@ function changeCustomInfoStyle() {
   // Ensure the visible cell shows the updated prompt immediately
   cfg.getRange(INFO_PROMPT_ROW, 2).setValue(newPrompt);
   ui.alert('Custom info prompt updated.');
-    logAction(fn, 'Completed');
+    logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
   } catch (e) {
-    logAction(fn, 'Failed: ' + e.message);
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
     throw e;
   }
 }
 
 function revertToPreviousInfoStyle() {
   const fn = 'revertToPreviousInfoStyle';
+  const start = Date.now();
   try {
     const ui = SpreadsheetApp.getUi();
     const cfg = ensureConfigSheet();
@@ -2151,24 +2224,25 @@ function revertToPreviousInfoStyle() {
   cfg.getRange(PREVIOUS_INFO_ROW, 2).setValue(current);
   cfg.getRange(INFO_PROMPT_ROW, 2).setValue(prev);
   ui.alert('Reverted to previous custom info style.');
-    logAction(fn, 'Completed');
+    logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
   } catch (e) {
-    logAction(fn, 'Failed: ' + e.message);
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
     throw e;
   }
 }
 
 function revertToDefaultInfoStyle() {
   const fn = 'revertToDefaultInfoStyle';
+  const start = Date.now();
   try {
     const cfg = ensureConfigSheet();
     const current = cfg.getRange(INFO_PROMPT_ROW, 2).getValue();
     cfg.getRange(PREVIOUS_INFO_ROW, 2).setValue(current);
     cfg.getRange(INFO_PROMPT_ROW, 2).setValue(DEFAULT_CUSTOM_INFO_GUIDELINES);
     SpreadsheetApp.getUi().alert('Reverted to default custom info style.');
-    logAction(fn, 'Completed');
+    logAction(fn, 'Completed', Math.round((Date.now()-start)/1000));
   } catch (e) {
-    logAction(fn, 'Failed: ' + e.message);
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000));
     throw e;
   }
 }
@@ -2180,21 +2254,23 @@ function revertToDefaultInfoStyle() {
  */
 function runCombinedScrapesOptimized() {
   const fn = 'runCombinedScrapesOptimized';
+  const start = Date.now();
+  let rowCount = 0;
   try {
     const ui = SpreadsheetApp.getUi();
     const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(getConfig('SHEET_NAME'));
     const flagCol = letterToColumn(getColumnConfig('FIND_OWNER_INFO_COL_LETTER'));
     const data = sheet.getDataRange().getValues();
-    const startTime = new Date();
 
   const flaggedRows = data.map((row, index) => ({ row, index })) // Keep original index
                          .filter(item => item.row[flagCol - 1] === 1);
 
     if (flaggedRows.length === 0) {
       ui.alert('🛑 No rows flagged with "1" to process.');
-      logAction(fn, 'Failed: no rows flagged');
+      logAction(fn, 'Failed: no rows flagged', Math.round((Date.now()-start)/1000), 0);
       return;
     }
+    rowCount = flaggedRows.length;
   // ---  START: ADDED UI ALERT ---
   const n = flaggedRows.length;
   const alertMessage = 
@@ -2265,9 +2341,9 @@ function runCombinedScrapesOptimized() {
     `• Customizations created: ${customCount}`,
     ui.ButtonSet.OK
   );
-    logAction(fn, 'Completed');
+    logAction(fn, 'Completed', Math.round((Date.now()-start)/1000), rowCount);
   } catch (e) {
-    logAction(fn, 'Failed: ' + e.message);
+    logAction(fn, 'Failed: ' + e.message, Math.round((Date.now()-start)/1000), rowCount);
     throw e;
   }
 }


### PR DESCRIPTION
## Summary
- expand logs sheet with Duration and Rows columns
- update `logAction` for optional duration and row data
- capture timing in menu actions and record to logs
- log number of processed rows for key functions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bf20388a48322889dd4fa04da54f4