### PR TITLE
Add HTML sidebar and sidebar menu

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -297,53 +297,38 @@ const ADMIN_USERS = [
   'diego@mirantepartners.com'
 ];
 
+/**
+ * Called whenever the spreadsheet is opened.
+ * Adds a single menu item that launches the sidebar UI.
+ */
 function onOpen(e) {
   const ui = SpreadsheetApp.getUi();
+  ui.createAddonMenu()
+    .addItem('🚀 Open Toolkit Sidebar', 'showSidebar')
+    .addToUi();
+}
+
+/**
+ * Displays the custom HTML sidebar.
+ * It checks if the user is an admin and passes that information to the HTML template.
+ */
+function showSidebar() {
   const userEmail = Session.getActiveUser().getEmail();
+  const isAdmin = ADMIN_USERS.includes(userEmail);
 
-  // Warn if not configured by checking for essential properties.
-  const sheetName = readConfig('SHEET_NAME');
-  const companyCol = readConfig('COMPANY_COL_LETTER');
-  if (!sheetName || !companyCol) {
-    ui.alert(
-      'Toolkit not configured yet!',
-      'Please run *⚙️ 0 - Setup Columns & Sheet Name* before using any of the menu commands.',
-      ui.ButtonSet.OK
-    );
-  }
+  const htmlTemplate = HtmlService.createTemplateFromFile('Sidebar');
+  htmlTemplate.isAdmin = isAdmin;
 
-  // Build the main add‑on menu
-  const menu = ui.createAddonMenu()
-    .addItem('⚙️ 0 - Setup Columns & Sheet Name', 'setupColumnsForThisSheet')
-    // 🔍 Find…
-    .addItem('🔍 1 - Enrich Data',       'enrichData')
-    .addSubMenu(ui.createMenu('✨ 2 - Create Customization')
-      .addItem('✨ Create Customization', 'runCombinedScrapesOptimized')
-      .addItem('🪄 Change Custom Info Style', 'changeCustomInfoStyle')
-      .addItem('↩️ Revert to previous custom info', 'revertToPreviousInfoStyle')
-      .addItem('🔄 Revert to default custom info', 'revertToDefaultInfoStyle'))
+  const html = htmlTemplate.evaluate().setTitle('Mirante Partners Toolkit ⛰️');
+  SpreadsheetApp.getUi().showSidebar(html);
+}
 
-    // 🚀 Upload to Apollo
-    .addSubMenu(ui.createMenu('🚀 3 - Upload to Apollo')
-      .addItem('🚀 Upload Contacts to Apollo',  'uploadContacts')
-      .addItem('🔄 Refresh Senders & Sequences','refreshLookups')
-    );
-  // Only add "Admin Functions" if the user is in your ADMIN_USERS list
-  if (ADMIN_USERS.indexOf(userEmail) !== -1) {
-      menu
-        .addSubMenu(ui.createMenu('👑 Admin Functions')
-          .addItem('🔑 Setup API Keys (Global)',    'setupApiKey')
-          .addSubMenu(ui.createMenu('✉️ Create Full Email - beta')
-            .addItem('✉️ Create Full Email (beta)',    'createFullEmail')
-            .addItem('🪄 Change Email Optimization Style', 'changeEmailOptimizationStyle')
-            .addItem('↩️ Revert to previous style',      'revertToPreviousCustomization')
-            .addItem('🔄 Revert to default style',       'revertToDefaultCustomization'))
-          .addSeparator()
-          .addItem('🏷️ Define Credits', 'defineCredits')
-        );
-  }
-
-  menu.addToUi();
+/**
+ * Displays an error message as a toast notification in the spreadsheet.
+ * @param {string} message The error message to display.
+ */
+function showErrorToast(message) {
+  SpreadsheetApp.getActiveSpreadsheet().toast(message, 'Error', -1);
 }
 
 /**

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        padding: 10px;
+        background-color: #f8f9fa;
+      }
+      .container {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      button, .button-like {
+        width: 100%;
+        padding: 10px;
+        text-align: left;
+        background-color: #fff;
+        color: #333;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+        transition: background-color 0.2s;
+      }
+      button:hover {
+        background-color: #f0f0f0;
+      }
+      .collapsible {
+        background-color: #f1f1f1;
+        cursor: pointer;
+        padding: 10px;
+        width: 100%;
+        border: none;
+        text-align: left;
+        outline: none;
+        font-size: 15px;
+        border-radius: 4px;
+        margin-top: 5px;
+      }
+      .active, .collapsible:hover {
+        background-color: #ddd;
+      }
+      .content {
+        padding: 0 10px;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.2s ease-out;
+        background-color: #f9f9f9;
+        border-radius: 0 0 4px 4px;
+        border: 1px solid #ccc;
+        border-top: none;
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+        padding-top: 5px;
+        padding-bottom: 5px;
+      }
+      .content button {
+        background-color: #e7e7e7;
+      }
+      #loader {
+        display: none;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        border: 5px solid #f3f3f3;
+        border-top: 5px solid #3498db;
+        border-radius: 50%;
+        width: 50px;
+        height: 50px;
+        animation: spin 1s linear infinite;
+        z-index: 1000;
+      }
+      @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="loader"></div>
+    <div class="container">
+      <h3>Mirante Partners Toolkit ⛰️</h3>
+      
+      <button onclick="runFunction('setupColumnsForThisSheet')">⚙️ 0 - Setup Columns & Sheet Name</button>
+      <button onclick="runFunction('enrichData')">🔍 1 - Enrich Data</button>
+
+      <button class="collapsible">✨ 2 - Create Customization</button>
+      <div class="content">
+        <button onclick="runFunction('runCombinedScrapesOptimized')">✨ Create Customization</button>
+        <button onclick="runFunction('changeCustomInfoStyle')">🪄 Change Custom Info Style</button>
+        <button onclick="runFunction('revertToPreviousInfoStyle')">↩️ Revert to previous</button>
+        <button onclick="runFunction('revertToDefaultInfoStyle')">🔄 Revert to default</button>
+      </div>
+
+      <button class="collapsible">🚀 3 - Upload to Apollo</button>
+      <div class="content">
+        <button onclick="runFunction('uploadContacts')">🚀 Upload Contacts to Apollo</button>
+        <button onclick="runFunction('refreshLookups')">🔄 Refresh Senders & Sequences</button>
+      </div>
+      
+      <? if (isAdmin) { ?>
+        <button class="collapsible">👑 Admin Functions</button>
+        <div class="content">
+            <button onclick="runFunction('setupApiKey')">🔑 Setup API Keys (Global)</button>
+            <button class="collapsible">✉️ Create Full Email - beta</button>
+            <div class="content">
+                <button onclick="runFunction('createFullEmail')">✉️ Create Full Email (beta)</button>
+                <button onclick="runFunction('changeEmailOptimizationStyle')">🪄 Change Email Optimization Style</button>
+                <button onclick="runFunction('revertToPreviousCustomization')">↩️ Revert to previous style</button>
+                <button onclick="runFunction('revertToDefaultCustomization')">🔄 Revert to default style</button>
+            </div>
+            <button onclick="runFunction('defineCredits')">🏷️ Define Credits</button>
+        </div>
+      <? } ?>
+
+    </div>
+
+    <script>
+      function showLoader(show) {
+        document.getElementById('loader').style.display = show ? 'block' : 'none';
+      }
+
+      function runFunction(functionName) {
+        showLoader(true);
+        google.script.run
+          .withSuccessHandler(() => {
+            showLoader(false);
+          })
+          .withFailureHandler(error => {
+            showLoader(false);
+            google.script.run.showErrorToast(error.message);
+          })
+          [functionName]();
+      }
+      
+      // JavaScript for collapsible sections
+      var coll = document.getElementsByClassName("collapsible");
+      for (var i = 0; i < coll.length; i++) {
+        coll[i].addEventListener("click", function() {
+          this.classList.toggle("active");
+          var content = this.nextElementSibling;
+          if (content.style.maxHeight){
+            content.style.maxHeight = null;
+          } else {
+            content.style.maxHeight = content.scrollHeight + "px";
+          } 
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/appsscript.json
+++ b/appsscript.json
@@ -30,6 +30,9 @@
       "useLocaleFromApp": true
     },
     "sheets": {
+      "homepageTrigger": {
+        "runFunction": "showSidebar"
+      },
       "onFileScopeGrantedTrigger": {
         "runFunction": "onOpen"
       }


### PR DESCRIPTION
## Summary
- replace the old menu-based `onOpen` with a sidebar launcher
- implement `showSidebar` and `showErrorToast` helpers
- add new Sidebar.html UI
- update manifest to use `showSidebar` as homepage trigger
- clarify documentation for the sidebar launcher

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687c12bb677883228eb1b8f645762b17